### PR TITLE
wrapped paragraph at 80-char

### DIFF
--- a/docs/about-us.ftd
+++ b/docs/about-us.ftd
@@ -25,7 +25,8 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `about-us` component for [admint.io/about](https://admint.io/#/about), 
+We have developed the `about-us` component for 
+[admint.io/about](https://admint.io/#/about), 
 which matches the design currently displayed on the live site.
 
 -- ds.h3: How to use?
@@ -40,8 +41,8 @@ lang: ftd
 
 -- ds.markdown:
 
-Once you import the `lib` inside your `.ftd` file, use the `ad-card` component by
-adding all required attributes of it.
+Once you import the `lib` inside your `.ftd` file, use the `ad-card` component
+by adding all required attributes of it.
 
 -- ds.rendered:
 

--- a/docs/advertisement-card.ftd
+++ b/docs/advertisement-card.ftd
@@ -25,13 +25,14 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `advertisement-card` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `advertisement-card` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed
+ on the live site.
 
 -- ds.h3: How to use?
 
-To use the `advertisement-card` component you need to import `lib.ftd` inside your `.ftd`
-file, as shown below:
+To use the `advertisement-card` component you need to import `lib.ftd` inside
+your `.ftd` file, as shown below:
 
 -- ds.code:
 lang: ftd
@@ -40,8 +41,8 @@ lang: ftd
 
 -- ds.markdown:
 
-Once you import the `lib` inside your `.ftd` file, use the `advertisement-card` component by
-adding all required attributes of it.
+Once you import the `lib` inside your `.ftd` file, use the `advertisement-card`
+component by adding all required attributes of it.
 
 -- ds.rendered:
 

--- a/docs/advertisement-cards.ftd
+++ b/docs/advertisement-cards.ftd
@@ -87,18 +87,20 @@ web 3.0 budget?
 
 -- ds.page.body:
 
-We have developed the `advertisement` and `advertisement-card` component for [admint.io](https://admint.io/), 
+We have developed the `advertisement` and `advertisement-card` component for 
+[admint.io](https://admint.io/), 
 which matches the design currently displayed on the live site.
 
 The `advertisement` component accepts `title` and `tagline` attributes. It has
-provision to accept child components. You can add as many as child `advertisement-card`
-components to it. Each `advertisement-card` uses `50%` width of `advertisement` component
-which means `2` card per row will be displayed.
+provision to accept child components. You can add as many as child
+`advertisement-card` components to it. Each `advertisement-card` uses `50%`
+width of `advertisement` component which means `2` card per row will be
+displayed.
 
 -- ds.h3: How to use?
 
-To use the `advertisement` and `advertisement-card` component you need to import `lib.ftd`
-inside your `.ftd` file, as shown below:
+To use the `advertisement` and `advertisement-card` component you need to 
+import`lib.ftd` inside your `.ftd` file, as shown below:
 
 -- ds.code:
 lang: ftd

--- a/docs/carousel-2.ftd
+++ b/docs/carousel-2.ftd
@@ -97,8 +97,9 @@ reset: $current-active
 
 -- ds.page.body:
 
-We have developed the `carousel` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `carousel` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed 
+on the live site.
 
 -- ds.h3: How to use?
 

--- a/docs/help-banner.ftd
+++ b/docs/help-banner.ftd
@@ -25,13 +25,14 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `help-banner` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `help-banner` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed 
+on the live site.
 
 -- ds.h3: How to use?
 
-To use the `help-banner` component you need to import `lib.ftd` inside your `.ftd`
-file, as shown below:
+To use the `help-banner` component you need to import `lib.ftd` inside your
+`.ftd` file, as shown below:
 
 -- ds.code:
 lang: ftd
@@ -40,8 +41,8 @@ lang: ftd
 
 -- ds.markdown:
 
-Once you import the `lib` inside your `.ftd` file, use the `help-banner` component by
-adding all required attributes of it.
+Once you import the `lib` inside your `.ftd` file, use the `help-banner`
+component by adding all required attributes of it.
 
 -- ds.rendered:
 

--- a/docs/how-it-works.ftd
+++ b/docs/how-it-works.ftd
@@ -25,16 +25,17 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `how-it-works` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `how-it-works` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed 
+on the live site.
 
 -- ds.h3: How to use?
 
-The `how-it-works` component accepts `ftd` `child` components also. Check [How it
-works](index.html#how-it-works) of homepage. It have `carousel` as child and
-`carousel` items as children. It can be used to add any other components as its
-children. We recommend to close it with `-- end: how-it-works`, if it contains
-multiple childrens.
+The `how-it-works` component accepts `ftd` `child` components also. Check 
+[How it works](index.html#how-it-works) of homepage. 
+It have `carousel` as child and `carousel` items as children. It can be used 
+to add any other components as its children. We recommend to close it with 
+`-- end: how-it-works`, if it contains multiple childrens.
 
 To use the `how-it-works` component you need to import `lib.ftd` inside your `.ftd`
 file, as shown below:
@@ -46,8 +47,8 @@ lang: ftd
 
 -- ds.markdown:
 
-Once you import the `lib` inside your `.ftd` file, use the `how-it-works` component by
-adding all required attributes of it.
+Once you import the `lib` inside your `.ftd` file, use the `how-it-works`
+component by adding all required attributes of it.
 
 -- ds.rendered:
 

--- a/docs/join-waitlist-form.ftd
+++ b/docs/join-waitlist-form.ftd
@@ -24,13 +24,14 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `join-waitlist-form` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `join-waitlist-form` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed 
+on the live site.
 
 -- ds.h3: How to use?
 
-To use `join-waitlist-form` component you need to `import` `lib` inside your `.ftd`
-file.
+To use `join-waitlist-form` component you need to `import` `lib` inside your
+`.ftd` file.
 
 -- ds.code:
 lang: ftd
@@ -40,8 +41,8 @@ lang: ftd
 
 -- ds.markdown:
 
-Once you import `lib` inside your `.ftd` file, use the `join-waitlist-form` component by
-adding all required attributes of it.
+Once you import `lib` inside your `.ftd` file, use the `join-waitlist-form`
+component by adding all required attributes of it.
 
 -- ds.rendered:
 

--- a/docs/join-waitlist-popup.ftd
+++ b/docs/join-waitlist-popup.ftd
@@ -25,8 +25,9 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `join-waitlist-popup` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `join-waitlist-popup` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed 
+on the live site.
 
 -- ds.h3: How to use?
 
@@ -42,8 +43,8 @@ lang: ftd
 
 Once you import `lib` inside your `.ftd` file, use the `join-waitlist-popup`
 component by adding all required attributes of it. Also, add global mutable
-variable `show-waitlist-popup` inside your `.ftd` file and pass it to `$visible:`
-attribute as shown in below code snippet:
+variable `show-waitlist-popup` inside your `.ftd` file and pass it to
+`$visible:` attribute as shown in below code snippet:
 
 -- ds.rendered:
 

--- a/docs/our-team.ftd
+++ b/docs/our-team.ftd
@@ -26,8 +26,9 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `our-team` component for [admint.io/about](https://admint.io/#/about), 
-which matches the design currently displayed on the live site.
+We have developed the `our-team` component for 
+[admint.io/about](https://admint.io/#/about), which matches the design 
+currently displayed on the live site.
 
 -- ds.h3: How to use?
 

--- a/docs/site-footer.ftd
+++ b/docs/site-footer.ftd
@@ -26,13 +26,14 @@ sections: $lib.sitemap.sections
 
 -- ds.page.body:
 
-We have developed the `site-footer` component for [admint.io/learn/](https://admint.io/learn/), 
-which matches the design currently displayed on the live site.
+We have developed the `site-footer` component for 
+[admint.io/learn/](https://admint.io/learn/), which matches the design 
+currently displayed on the live site.
 
 -- ds.h3: How to use?
 
-To use the `site-footer` component you need to import `lib.ftd` inside your `.ftd`
-file.
+To use the `site-footer` component you need to import `lib.ftd` inside your
+`.ftd` file.
 
 -- ds.code:
 lang: ftd

--- a/docs/sneak-peak.ftd
+++ b/docs/sneak-peak.ftd
@@ -63,8 +63,9 @@ display: inline
 
 -- ds.page.body:
 
-We have developed the `sneak-peak` component for [admint.io](https://admint.io/), 
-which matches the design currently displayed on the live site.
+We have developed the `sneak-peak` component for 
+[admint.io](https://admint.io/), which matches the design currently displayed
+ on the live site.
 
 -- ds.h3: How to use?
 


### PR DESCRIPTION
Following is the minor formatting change done:

Updated the [admint.io/docs](https://github.com/FifthTry/admint.io/tree/main/docs) documents by applying `Wrap Paragraph at Ruler` which is mentioned in the [80-char](https://fastn.io/formatting/#80-char) guideline.